### PR TITLE
Standard deviation not variance should be indicated in sp.stats.norm.rvs()

### DIFF
--- a/annopred/pred_main.py
+++ b/annopred/pred_main.py
@@ -444,7 +444,7 @@ def non_infinitesimal_mcmc(beta_hats, Pi, Sigi2, sig_12, start_betas=None, h2=No
         
                 if rand_ps[i] < postp * alpha:
                     #Sample from the posterior Gaussian dist.
-                    proposed_beta = stats.norm.rvs(0, (hdmp_hdmpn) * sig_12, size=1) + hdmp_hdmpn * res_beta_hat_i
+                    proposed_beta = stats.norm.rvs(0, np.sqrt((hdmp_hdmpn) * sig_12), size=1) + hdmp_hdmpn * res_beta_hat_i
         
                 else:
                     #Sample 0


### PR DESCRIPTION
Dear @yiminghu 
I have found that variance is now indicated in sp.stats.norm.rvs() instead of standard variation.
This could have influence upon estimated effect sizes and convergence in Gibbs Sampling.

Best regards,
@rickyota